### PR TITLE
fix(hm/refnode/ref-rebuild): fix base path and enable worktree access

### DIFF
--- a/pkgs/ref-rebuild/default.nix
+++ b/pkgs/ref-rebuild/default.nix
@@ -1,7 +1,9 @@
 {
-  writeShellScriptBin,
+  writeShellApplication,
   pkgs,
 }:
-writeShellScriptBin "ref-rebuild" ''
-  darwin-rebuild switch --flake $HOME/src/github.com/refnode/nixcfg.git/main
-''
+writeShellApplication {
+  name = "ref-rebuild";
+
+  text = builtins.readFile ./script.sh;
+}

--- a/pkgs/ref-rebuild/script.sh
+++ b/pkgs/ref-rebuild/script.sh
@@ -1,0 +1,12 @@
+# shellcheck disable=SC2148
+
+BRANCH=${1:-main}
+
+FLAKE_PATH="$HOME/src/github.com/refnode/nixcfg/$BRANCH"
+
+if [ ! -d "$FLAKE_PATH" ]; then
+    echo "Flake path not present $FLAKE_PATH"
+    exit 1
+fi
+
+darwin-rebuild switch --flake "$FLAKE_PATH"


### PR DESCRIPTION
Fix the base path of the repo in my $HOME and enable the use of git
worktree access with first parameter that defaults to main.

Also use writeShellApplication to benefit from shellchecker.
