### PR TITLE
feat(pkgs): add new script ref-git-bare-clone-update

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -9,4 +9,5 @@
   ref-mail-cdv = pkgs.callPackage ../pkgs/ref-mail-cdv {};
   ref-irc = pkgs.callPackage ../pkgs/ref-irc {};
   ref-pathlist = pkgs.callPackage ../pkgs/ref-pathlist {};
+  ref-git-bare-clone-update = pkgs.callPackage ./ref-git-bare-clone-update {};
 }

--- a/pkgs/ref-git-bare-clone-update/default.nix
+++ b/pkgs/ref-git-bare-clone-update/default.nix
@@ -1,0 +1,11 @@
+{
+  writeShellApplication,
+  pkgs,
+}:
+writeShellApplication {
+  name = "ref-git-bare-clone-update";
+
+  runtimeInputs = [pkgs.git pkgs.gnugrep];
+
+  text = builtins.readFile ./script.sh;
+}

--- a/pkgs/ref-git-bare-clone-update/script.sh
+++ b/pkgs/ref-git-bare-clone-update/script.sh
@@ -1,0 +1,26 @@
+# shellcheck disable=SC2148
+
+# Called from garden tool, on bare normally no remote origin fetch
+# informations are present on the repo. In the garden config for the
+# repos the remote.origin.fetch is already set in the git config for
+# the repo, but not fetch is run. Therefore run a fetch first.
+git fetch origin
+
+# The bare repo itself lives in parent-folder/.bare/
+# Start point when called from git garden is the `.bare` folder,
+# therefore change up into parent-folder for all tasks
+cd ..
+
+# If no `.git` file points to `./.bare`, create it
+if [ ! -f ./.git ]; then echo "gitdir: ./.bare" >./.git; fi
+
+# Set refs/remotes/origin/HEAD according to remote repo
+# and fetch the default repo from the output as
+# 'HEAD set to main'
+origin_head="$(git remote set-head origin -a)"
+default_branch=$(echo "$origin_head" | grep --only-matching '[^\ ]*$')
+
+# If no worktree for the default branch is present, create it.
+if [ ! -d "./$default_branch" ]; then
+    git worktree add "$default_branch"
+fi

--- a/users/refnode/default.nix
+++ b/users/refnode/default.nix
@@ -32,6 +32,7 @@
     ref-mail-sync
     ref-irc
     ref-pathlist
+    ref-git-bare-clone-update
     cookiecutter
     qmk
     git-annex


### PR DESCRIPTION
Integrate script that gets triggered from a git garden configuration.
As I like to use git worktrees on bare repos
and [garden](https://garden-rs.gitlab.io) only supports worktree on
classic clones (as I understand at least), I let the garden tool clone
the repos from my gh account as bare clones, let garden set gitconfig
parameter and trigger this script to perform tasks not done by the
garden tools.
