### PR TITLE
refactor pre commit checks

### DIFF
--- a/checks/default.nix
+++ b/checks/default.nix
@@ -6,10 +6,27 @@
   pre-commit-check = pre-commit-hooks.lib.${system}.run {
     src = ./.;
     hooks = {
+      # common checks checks
+      trim-trailing-whitespace.enable = true;
+      mixed-line-endings.enable = true;
+      end-of-file-fixer.enable = true;
+      check-added-large-files.enable = true;
+      check-case-conflicts.enable = true;
+      check-merge-conflicts.enable = true;
+
+      # nix file checks
       alejandra.enable = true;
-      shellcheck.enable = true;
-      yamllint.enable = true;
+
+      # markdown checks
       markdownlint.enable = true;
+
+      # yaml checks
+      yamllint.enable = true;
+
+      # shell script checks
+      shellcheck.enable = true;
+
+      # GitHub actions checks
       actionlint.enable = true;
     };
   };

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -1,0 +1,16 @@
+{
+  pre-commit-hooks,
+  system,
+  ...
+}: {
+  pre-commit-check = pre-commit-hooks.lib.${system}.run {
+    src = ./.;
+    hooks = {
+      alejandra.enable = true;
+      shellcheck.enable = true;
+      yamllint.enable = true;
+      markdownlint.enable = true;
+      actionlint.enable = true;
+    };
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -136,16 +136,16 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1728092656,
-        "narHash": "sha256-eMeCTJZ5xBeQ0f9Os7K8DThNVSo9gy4umZLDfF5q6OM=",
+        "lastModified": 1730814269,
+        "narHash": "sha256-fWPHyhYE6xvMI1eGY3pwBTq85wcy1YXqdzTZF+06nOg=",
         "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "rev": "1211305a5b237771e13fcca0c51e60ad47326a9a",
+        "repo": "git-hooks.nix",
+        "rev": "d70155fdc00df4628446352fc58adc640cd705c2",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
+        "repo": "git-hooks.nix",
         "type": "github"
       }
     },

--- a/shell.nix
+++ b/shell.nix
@@ -1,10 +1,12 @@
 {
   pkgs ? import <nixpkgs> {},
-  shellHook ? "",
+  checks,
   ...
 }:
 pkgs.mkShell {
-  buildInputs = with pkgs; [
+  inherit (checks.pre-commit-check) shellHook;
+  buildInputs = checks.pre-commit-check.enabledPackages;
+  nativeBuildInputs = with pkgs; [
     # Git and nix should always be present in the devshell
     git
     # It's quite handy to have home-manager present in the devshell when
@@ -22,6 +24,4 @@ pkgs.mkShell {
     yq-go
     just
   ];
-
-  inherit shellHook;
 }

--- a/users/refnode/modules/zsh.sh
+++ b/users/refnode/modules/zsh.sh
@@ -38,7 +38,7 @@ fzf-git-widget() {
     return 0
   fi
   zle push-line # Clear buffer. Auto-restored on next prompt.
-  # shellcheck disable=SC2034 # wrong interpretation, BUFFER is used by zle accept-line 
+  # shellcheck disable=SC2034 # wrong interpretation, BUFFER is used by zle accept-line
   # shellcheck disable=SC2296
   BUFFER="builtin cd -- ${(q)dir:a}"
   zle accept-line


### PR DESCRIPTION
Update flake input for pre-commit-hooks, as the repo was renamed to git-hooks.

Refactoring the pre-commit-hooks configuration, following the example
provided in the README to use checks for that. Instead of keeping the
checks in `flake.nix` directly, start to manage the checks in the
checks dir.

Rename the original buildInputs attribute of mkShell as
nativeBuildInputs should be used for commands that need to run
at build time like cmake or shell hooks, according to a discourse
thread.

So that would also be the case for the pkgs required by the
pre-commit-checks, but I keep the config as given in the README
first.

Active common checks for typical format weaknesses.
