### PR TITLE
make nixpkgs-unstable accessible through pkgs.unstable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,11 +112,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1728018373,
-        "narHash": "sha256-NOiTvBbRLIOe5F6RbHaAh6++BNjsb149fGZd1T4+KBg=",
+        "lastModified": 1731139594,
+        "narHash": "sha256-IigrKK3vYRpUu+HEjPL/phrfh7Ox881er1UEsZvw9Q4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bc947f541ae55e999ffdb4013441347d83b00feb",
+        "rev": "76612b17c0ce71689921ca12d9ffdc9c23ce40b2",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -70,19 +70,10 @@
       system:
         import nixpkgs {
           inherit system;
-          overlays = [
-            localOverlays
-          ];
-          # activate unfree when I know that I need it.
-          config.allowUnfree = false;
-        }
-    );
-
-    unstablePkgsFor = nixpkgs.lib.genAttrs supportedSystems (
-      system:
-        import nixpkgs-unstable {
-          inherit system;
-          overlays = [];
+          # overlays = [
+          #   localOverlays
+          # ];
+          overlays = localOverlays;
           # activate unfree when I know that I need it.
           config.allowUnfree = false;
         }
@@ -92,7 +83,9 @@
     # could be also done by just passing additional args to the submodules
     # using the overlay approach, the repo local derivations are addressable
     # by pkgs.myderivation in the submodule
-    localOverlays = import ./overlays;
+    localOverlays = builtins.attrValues (
+      import ./overlays {inherit nixpkgs-unstable;}
+    );
   in {
     formatter = pkgsForEachSystem (pkgs: pkgs.alejandra);
 
@@ -118,12 +111,10 @@
     darwinConfigurations = let
       system = "aarch64-darwin";
       pkgs = pkgsFor.${system};
-      pkgsUnstable = unstablePkgsFor.${system};
     in {
       defiant = import ./lib {
         inherit
           pkgs
-          pkgsUnstable
           nix-darwin
           home-manager
           system

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,6 +1,5 @@
 {
   pkgs,
-  pkgsUnstable,
   nix-darwin,
   home-manager,
   system,
@@ -23,7 +22,7 @@ in
         home-manager.useGlobalPkgs = true;
         home-manager.useUserPackages = true;
         home-manager.users.${user} = import userHomeConfig {
-          inherit pkgs pkgsUnstable user;
+          inherit pkgs user;
         };
         # Optionally, use home-manager.extraSpecialArgs to pass
         # arguments to home.nix

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -1,1 +1,11 @@
-final: prev: import ../pkgs {pkgs = final;}
+{nixpkgs-unstable, ...}: {
+  addons = final: prev: import ../pkgs {pkgs = final;};
+
+  unstable-pkgs = final: prev: {
+    unstable = import nixpkgs-unstable {
+      system = final.system;
+      # activate unfree when I know that I need it.
+      config.allowUnfree = false;
+    };
+  };
+}

--- a/users/refnode/default.nix
+++ b/users/refnode/default.nix
@@ -140,6 +140,7 @@
   programs.home-manager.enable = true;
   programs.neovim = {
     enable = true;
+    package = pkgs.unstable.neovim-unwrapped;
     defaultEditor = true;
     vimAlias = true;
     vimdiffAlias = true;

--- a/users/refnode/default.nix
+++ b/users/refnode/default.nix
@@ -1,10 +1,18 @@
 {
   pkgs,
-  pkgsUnstable,
   user,
   ...
-}: let
-  userPkgs = with pkgs; [
+}: {
+  imports = [
+    ./modules/zsh.nix
+  ];
+
+  # Don't change this when you change package input. Leave it alone.
+  home.stateVersion = "23.11";
+
+  # specify my home-manager configs
+  # home.packages = userPkgs ++ userPkgsUnstable;
+  home.packages = with pkgs; [
     curl
     less
     htop
@@ -73,64 +81,52 @@
     vdirsyncer
     khard
     khal
-  ];
 
-  userPkgsUnstable = with pkgsUnstable; [
-    fd
-    bat
-    eza
-    ripgrep
-    awscli2
-    google-cloud-sdk
-    lazygit
-    glab
-    graphviz
-    plantuml-c4
-    ffmpeg_7
-    msmtp
-    docker-client
-    fluxcd
-    go
-    gopls
-    goreleaser
-    nodejs_22
-    yubikey-manager
-    platformio
+    unstable.fd
+    unstable.bat
+    unstable.eza
+    unstable.ripgrep
+    unstable.awscli2
+    unstable.google-cloud-sdk
+    unstable.lazygit
+    unstable.glab
+    unstable.graphviz
+    unstable.plantuml-c4
+    unstable.ffmpeg_7
+    unstable.msmtp
+    unstable.docker-client
+    unstable.fluxcd
+    unstable.go
+    unstable.gopls
+    unstable.goreleaser
+    unstable.nodejs_22
+    unstable.yubikey-manager
+    unstable.platformio
     # encryption
-    sops
+    unstable.sops
     # kubernetes tools
-    kubectl
-    kubectx
-    kubelogin
-    kubelogin-oidc
-    krew
-    kustomize
-    kube-linter
-    kubeconform
-    kind
-    k9s
-    stern
-    k6
-    openshift
-    dive
-    crane
-    sonobuoy
-    opentofu
-    kubeone
+    unstable.kubectl
+    unstable.kubectx
+    unstable.kubelogin
+    unstable.kubelogin-oidc
+    unstable.krew
+    unstable.kustomize
+    unstable.kube-linter
+    unstable.kubeconform
+    unstable.kind
+    unstable.k9s
+    unstable.stern
+    unstable.k6
+    unstable.openshift
+    unstable.dive
+    unstable.crane
+    unstable.sonobuoy
+    unstable.opentofu
+    unstable.kubeone
     ##
-    sqlite
-    mob
+    unstable.sqlite
+    unstable.mob
   ];
-in {
-  imports = [
-    ./modules/zsh.nix
-  ];
-
-  # Don't change this when you change package input. Leave it alone.
-  home.stateVersion = "23.11";
-
-  # specify my home-manager configs
-  home.packages = userPkgs ++ userPkgsUnstable;
 
   home.sessionVariables = {
     PAGER = "${pkgs.bat}/bin/bat";


### PR DESCRIPTION
Add an overlay that injects nixpkgs-unstable as pkgs.unstable making it
more convinient to access unstable pkgs without passing an extra var
all the time.

Cleanup and aligning the lib and hm/refnode resources.

Use unstable neovim.
