### PR TITLE
refactor: phase1 modularizing the host config for workplace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: "CI"
 on:  # yamllint disable-line rule:truthy
   pull_request:
   push:
+    branches:
+      - main
 
 jobs:
   flake-general-checks:

--- a/flake.lock
+++ b/flake.lock
@@ -44,11 +44,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733050161,
-        "narHash": "sha256-lYnT+EYE47f5yY3KS/Kd4pJ6CO9fhCqumkYYkQ3TK20=",
+        "lastModified": 1734366194,
+        "narHash": "sha256-vykpJ1xsdkv0j8WOVXrRFHUAdp9NXHpxdnn1F4pYgSw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "62d536255879be574ebfe9b87c4ac194febf47c5",
+        "rev": "80b0fdf483c5d1cb75aaad909bd390d48673857f",
         "type": "github"
       },
       "original": {
@@ -65,11 +65,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733351379,
-        "narHash": "sha256-MTMsAhXxMMVHVN99jT8E0afOAOtt3JQWjYpTja94PAU=",
+        "lastModified": 1735218083,
+        "narHash": "sha256-MoUAbmXz9TEr7zlKDRO56DBJHe30+7B5X7nhXm+Vpc8=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "55d07816a0944f06a9df5ef174999a72fa4060c7",
+        "rev": "bc03f7818771a75716966ce8c23110b715eff2aa",
         "type": "github"
       },
       "original": {
@@ -80,11 +80,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733261153,
-        "narHash": "sha256-eq51hyiaIwtWo19fPEeE0Zr2s83DYMKJoukNLgGGpek=",
+        "lastModified": 1735141468,
+        "narHash": "sha256-VIAjBr1qGcEbmhLwQJD6TABppPMggzOvqFsqkDoMsAY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b681065d0919f7eb5309a93cea2cfa84dec9aa88",
+        "rev": "4005c3ff7505313cbc21081776ad0ce5dfd7a3ce",
         "type": "github"
       },
       "original": {
@@ -112,11 +112,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1733212471,
-        "narHash": "sha256-M1+uCoV5igihRfcUKrr1riygbe73/dzNnzPsmaLCmpo=",
+        "lastModified": 1734649271,
+        "narHash": "sha256-4EVBRhOjMDuGtMaofAIqzJbg4Ql7Ai0PSeuVZTHjyKQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "55d15ad12a74eb7d4646254e13638ad0c4128776",
+        "rev": "d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
         "type": "github"
       },
       "original": {
@@ -136,11 +136,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1733318908,
-        "narHash": "sha256-SVQVsbafSM1dJ4fpgyBqLZ+Lft+jcQuMtEL3lQWx2Sk=",
+        "lastModified": 1734797603,
+        "narHash": "sha256-ulZN7ps8nBV31SE+dwkDvKIzvN6hroRY8sYOT0w+E28=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "6f4e2a2112050951a314d2733a994fbab94864c6",
+        "rev": "f0f0dc4920a903c3e08f5bdb9246bb572fcae498",
         "type": "github"
       },
       "original": {

--- a/hosts/common/core/default.nix
+++ b/hosts/common/core/default.nix
@@ -1,0 +1,34 @@
+{
+  pkgs,
+  inputs,
+  ...
+}: {
+  imports = [
+    ./nix.nix
+    ./fonts.nix
+  ];
+
+  environment = {
+    systemPackages = [
+      pkgs.coreutils
+      pkgs.neovim-unwrapped
+      pkgs.git
+    ];
+
+    shells = [
+      pkgs.bash
+      pkgs.zsh
+    ];
+  };
+
+  programs.zsh = {
+    enable = true;
+    enableCompletion = true;
+  };
+
+  home-manager.useGlobalPkgs = true;
+  home-manager.useUserPackages = true;
+  home-manager.extraSpecialArgs = {
+    inherit pkgs inputs;
+  };
+}

--- a/hosts/common/core/fonts.nix
+++ b/hosts/common/core/fonts.nix
@@ -1,0 +1,12 @@
+{pkgs, ...}: {
+  fonts = {
+    packages = [
+      (pkgs.nerdfonts.override {
+        fonts = [
+          "JetBrainsMono"
+          "Meslo"
+        ];
+      })
+    ];
+  };
+}

--- a/hosts/common/core/nix.nix
+++ b/hosts/common/core/nix.nix
@@ -1,0 +1,33 @@
+{...}: {
+  nix = {
+    # package = pkgs.nixVersions.nix_2_16;
+    checkConfig = true;
+    configureBuildUsers = true;
+    settings = {
+      # Necessary for using flakes on this system.
+      experimental-features = [
+        "nix-command"
+        "flakes"
+      ];
+      allowed-users = [
+        "@admin"
+      ];
+      # disable it, enabling leads to some symlink problems
+      # on macOS
+      auto-optimise-store = false;
+      cores = 6;
+      extra-sandbox-paths = [];
+      max-jobs = "auto";
+      require-sigs = true;
+      sandbox = false;
+      # substituters = [];
+      # trusted-public-keys = [];
+      trusted-users = [
+        "@admin"
+      ];
+    };
+  };
+
+  # Auto upgrade nix package and the daemon service.
+  services.nix-daemon.enable = true;
+}

--- a/hosts/common/darwin/core/default.nix
+++ b/hosts/common/darwin/core/default.nix
@@ -1,0 +1,3 @@
+{...}: {
+  environment.systemPath = ["/opt/homebrew/bin"];
+}

--- a/hosts/common/users/refnode/default.nix
+++ b/hosts/common/users/refnode/default.nix
@@ -1,0 +1,3 @@
+{config, ...}: {
+  home-manager.users.refnode = import ../../../../users/refnode/default.nix;
+}

--- a/hosts/defiant/default.nix
+++ b/hosts/defiant/default.nix
@@ -7,64 +7,10 @@
 }: {
   imports = [
     inputs.home-manager.darwinModules.home-manager
+    ../common/core
+    ../common/darwin/core
+    ../common/users/refnode
   ];
-
-  # List packages installed in system profile. To search by name, run:
-  # $ nix-env -qaP | grep wget
-  environment = {
-    systemPackages = [
-      pkgs.coreutils
-      pkgs.vim
-      pkgs.git
-    ];
-
-    shells = [
-      pkgs.bash
-      pkgs.zsh
-    ];
-  };
-
-  fonts = {
-    packages = [
-      (pkgs.nerdfonts.override {
-        fonts = [
-          "JetBrainsMono"
-          "Meslo"
-        ];
-      })
-    ];
-  };
-
-  # Auto upgrade nix package and the daemon service.
-  services.nix-daemon.enable = true;
-
-  nix = {
-    # package = pkgs.nixVersions.nix_2_16;
-    checkConfig = true;
-    configureBuildUsers = true;
-    settings = {
-      # Necessary for using flakes on this system.
-      experimental-features = "nix-command flakes";
-      allowed-users = [
-        "@admin"
-      ];
-      # disable it, enabling leads to some symlink problems
-      # on macOS
-      auto-optimise-store = false;
-      cores = 6;
-      extra-sandbox-paths = [];
-      max-jobs = "auto";
-      require-sigs = true;
-      sandbox = false;
-      # substituters = [];
-      # trusted-public-keys = [];
-      trusted-users = [
-        "@admin"
-      ];
-    };
-  };
-
-  programs.zsh.enable = true;
 
   # TODO https://discourse.nixos.org/t/give-name-label-comment-to-generations/45355
   system.configurationRevision = flake.rev or flake.dirtyRev or null;
@@ -83,10 +29,5 @@
     localHostName = "defiant";
   };
 
-  home-manager = {
-    useGlobalPkgs = true;
-    useUserPackages = true;
-    extraSpecialArgs = {inherit pkgs;};
-    users.refnode = import ../../users/refnode;
-  };
+  # home-manager.users.refnode = import ../../users/refnode;
 }


### PR DESCRIPTION
Following the great example of gh/Misterio77, I start to split out the
host configuration of the workplace into a `common/core` part, present on
all systems and a `common/optional` part, to include only on selected
modules. In difference to Misterio77 repo, I do not only manage Linux
systems, but darwin as well. Therefore this repo will also have a
`common/darwin` folder.
