### PR TITLE
refactor: delegate Rust toolchain management to rustup

### DIFF
--- a/users/refnode/default.nix
+++ b/users/refnode/default.nix
@@ -120,8 +120,7 @@
     unstable.sqlite
     unstable.mob
     pkgs.garden
-    unstable.cargo
-    unstable.rust-analyzer
+    unstable.rustup
     unstable.talosctl
     unstable.cilium-cli
     unstable.jujutsu


### PR DESCRIPTION
Replace nixpkgs-provided cargo and rust-analyzer with rustup, allowing rustup to manage the complete Rust toolchain outside of Nix control.