### PR TITLE
chore: upgrade to nixpkgs/nix-darwin/home-manager 25.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
         "type": "github"
       },
       "original": {
@@ -44,16 +44,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1747688870,
-        "narHash": "sha256-ypL9WAZfmJr5V70jEVzqGjjQzF0uCkz+AFQF7n9NmNc=",
+        "lastModified": 1753592768,
+        "narHash": "sha256-oV695RvbAE4+R9pcsT9shmp6zE/+IZe6evHWX63f2Qg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d5f1f641b289553927b3801580598d200a501863",
+        "rev": "fc3add429f21450359369af74c2375cb34a2d204",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-24.11",
+        "ref": "release-25.05",
         "repo": "home-manager",
         "type": "github"
       }
@@ -65,43 +65,43 @@
         ]
       },
       "locked": {
-        "lastModified": 1743127615,
-        "narHash": "sha256-+sMGqywrSr50BGMLMeY789mSrzjkoxZiu61eWjYS/8o=",
+        "lastModified": 1749744770,
+        "narHash": "sha256-MEM9XXHgBF/Cyv1RES1t6gqAX7/tvayBC1r/KPyK1ls=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "fc843893cecc1838a59713ee3e50e9e7edc6207c",
+        "rev": "536f951efb1ccda9b968e3c9dee39fbeb6d3fdeb",
         "type": "github"
       },
       "original": {
         "owner": "lnl7",
-        "ref": "nix-darwin-24.11",
+        "ref": "nix-darwin-25.05",
         "repo": "nix-darwin",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1747485343,
-        "narHash": "sha256-YbsZyuRE1tobO9sv0PUwg81QryYo3L1F3R3rF9bcG38=",
+        "lastModified": 1754563854,
+        "narHash": "sha256-YzNTExe3kMY9lYs23mZR7jsVHe5TWnpwNrsPOpFs/b8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9b5ac7ad45298d58640540d0323ca217f32a6762",
+        "rev": "e728d7ae4bb6394bbd19eec52b7358526a44c414",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-24.11",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1747542820,
-        "narHash": "sha256-GaOZntlJ6gPPbbkTLjbd8BMWaDYafhuuYRNrxCGnPJw=",
+        "lastModified": 1754498491,
+        "narHash": "sha256-erbiH2agUTD0Z30xcVSFcDHzkRvkRXOQ3lb887bcVrs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "292fa7d4f6519c074f0a50394dbbe69859bb6043",
+        "rev": "c2ae88e026f9525daf89587f3cbee584b92b6134",
         "type": "github"
       },
       "original": {
@@ -120,11 +120,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747372754,
-        "narHash": "sha256-2Y53NGIX2vxfie1rOW0Qb86vjRZ7ngizoo+bnXU9D9k=",
+        "lastModified": 1754416808,
+        "narHash": "sha256-c6yg0EQ9xVESx6HGDOCMcyRSjaTpNJP10ef+6fRcofA=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "80479b6ec16fefd9c1db3ea13aeb038c60530f46",
+        "rev": "9c52372878df6911f9afc1e2a1391f55e4dfc864",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,11 +2,11 @@
   description = "refnode's Nix configurations";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.11";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
-    nix-darwin.url = "github:lnl7/nix-darwin/nix-darwin-24.11";
+    nix-darwin.url = "github:lnl7/nix-darwin/nix-darwin-25.05";
     nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
-    home-manager.url = "github:nix-community/home-manager/release-24.11";
+    home-manager.url = "github:nix-community/home-manager/release-25.05";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
     pre-commit-hooks.url = "github:cachix/git-hooks.nix";
     pre-commit-hooks.inputs.nixpkgs.follows = "nixpkgs";

--- a/hosts/common/core/fonts.nix
+++ b/hosts/common/core/fonts.nix
@@ -1,12 +1,8 @@
 {pkgs, ...}: {
   fonts = {
     packages = [
-      (pkgs.nerdfonts.override {
-        fonts = [
-          "JetBrainsMono"
-          "Meslo"
-        ];
-      })
+      pkgs.nerd-fonts.jetbrains-mono
+      pkgs.nerd-fonts.meslo-lg
     ];
   };
 }

--- a/hosts/common/core/nix.nix
+++ b/hosts/common/core/nix.nix
@@ -2,7 +2,6 @@
   nix = {
     # package = pkgs.nixVersions.nix_2_16;
     checkConfig = true;
-    configureBuildUsers = true;
     settings = {
       # Necessary for using flakes on this system.
       experimental-features = [
@@ -28,6 +27,6 @@
     };
   };
 
-  # Auto upgrade nix package and the daemon service.
-  services.nix-daemon.enable = true;
+  # nix-darwin manages nix-daemon unconditionally when
+  nix.enable = true;
 }

--- a/hosts/common/darwin/core/default.nix
+++ b/hosts/common/darwin/core/default.nix
@@ -22,4 +22,6 @@
   };
 
   environment.systemPath = ["/opt/homebrew/bin"];
+
+  system.primaryUser = "refnode";
 }

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -5,7 +5,7 @@
     unstable = import nixpkgs-unstable {
       system = final.system;
       # activate unfree when I know that I need it.
-      config.allowUnfree = false;
+      config.allowUnfree = true;
     };
   };
 }

--- a/users/refnode/common/core/zsh/default.nix
+++ b/users/refnode/common/core/zsh/default.nix
@@ -29,7 +29,7 @@
     autosuggestion.enable = true;
     autosuggestion.highlight = "fg=#d8dee9,bg=#4c566a";
 
-    initExtra = builtins.readFile ./zsh.sh;
+    initContent = builtins.readFile ./zsh.sh;
   };
 
   # enable the fzf zsh integration by default history, file and directory

--- a/users/refnode/common/optional/desktop/darwin.nix
+++ b/users/refnode/common/optional/desktop/darwin.nix
@@ -5,6 +5,6 @@
   ...
 }: {
   home.packages = with pkgs; [
-    darwin.iproute2mac
+    iproute2mac
   ];
 }


### PR DESCRIPTION
Update all flake inputs from 24.11 to 25.05 and address breaking changes:
- nix-darwin: Replace services.nix-daemon.enable with nix.enable
- nix-darwin: Add system.primaryUser for new user management
- nixpkgs: Update nerd-fonts syntax (nerdfonts.override → nerd-fonts.*)
- nixpkgs: Fix package rename (darwin.iproute2mac → iproute2mac)
- home-manager: Replace deprecated initExtra with initContent
- nix-darwin: Remove deprecated configureBuildUsers option
- overlays: Fix allowUnfree configuration for unstable packages