### PR TITLE
refactor: modularize kubernetes and container tools

### DIFF
--- a/users/refnode/common/optional/kubernetes.nix
+++ b/users/refnode/common/optional/kubernetes.nix
@@ -1,0 +1,44 @@
+{ pkgs, ... }:
+
+{
+  # Kubernetes and container management tools
+  # Use case: Cloud-native development and operations
+  
+  home.packages = with pkgs; [
+    # Core Kubernetes tools
+    unstable.kubectl
+    unstable.kubectl-ktop
+    unstable.kubectx
+    unstable.kubelogin
+    unstable.kubelogin-oidc
+    unstable.krew
+    unstable.kustomize
+    unstable.kubernetes-helm
+    
+    # Development and testing
+    unstable.kind
+    unstable.k9s
+    unstable.stern
+    unstable.k6
+    
+    # Security and compliance
+    unstable.kube-linter
+    unstable.kubeconform
+    unstable.sonobuoy
+    
+    # Container tools
+    unstable.dive
+    unstable.crane
+    unstable.docker-client
+    
+    # Infrastructure as Code
+    unstable.opentofu
+    
+    # Platform-specific tools
+    unstable.openshift
+    unstable.kubeone
+    unstable.talosctl
+    unstable.cilium-cli
+    unstable.fluxcd
+  ];
+}

--- a/users/refnode/default.nix
+++ b/users/refnode/default.nix
@@ -2,6 +2,7 @@
   imports = [
     ./common/core
     ./common/optional/desktop/darwin.nix
+    ./common/optional/kubernetes.nix
   ];
 
   # specify my home-manager configs
@@ -86,8 +87,6 @@
     unstable.plantuml-c4
     unstable.ffmpeg_7
     unstable.msmtp
-    unstable.docker-client
-    unstable.fluxcd
     unstable.go
     unstable.gopls
     unstable.goreleaser
@@ -96,33 +95,11 @@
     unstable.platformio
     # encryption
     unstable.sops
-    # kubernetes tools
-    unstable.kubectl
-    unstable.kubectx
-    unstable.kubelogin
-    unstable.kubelogin-oidc
-    unstable.krew
-    unstable.kustomize
-    unstable.kubernetes-helm
-    unstable.kube-linter
-    unstable.kubeconform
-    unstable.kind
-    unstable.k9s
-    unstable.stern
-    unstable.k6
-    unstable.openshift
-    unstable.dive
-    unstable.crane
-    unstable.sonobuoy
-    unstable.opentofu
-    unstable.kubeone
     ##
     unstable.sqlite
     unstable.mob
     pkgs.garden
     unstable.rustup
-    unstable.talosctl
-    unstable.cilium-cli
     unstable.jujutsu
     unstable.minio-client
     unstable.kanata


### PR DESCRIPTION
Extract all kubernetes and container management tools from core user  packages into optional module for selective deployment:

- Add kubectl-ktop for enhanced cluster monitoring
- Include container tools: docker-client, dive, crane
- Add platform-specific: talosctl, cilium-cli, fluxcd, openshift
- Enable selective installation on systems needing k8s functionality