### PR TITLE
refactor: modularize rust development tools

### DIFF
--- a/users/refnode/common/optional/rust.nix
+++ b/users/refnode/common/optional/rust.nix
@@ -1,0 +1,10 @@
+{ pkgs, ... }:
+
+{
+  # Rust development tools
+  
+  home.packages = with pkgs; [
+    # Rust toolchain
+    unstable.rustup
+  ];
+}

--- a/users/refnode/default.nix
+++ b/users/refnode/default.nix
@@ -3,6 +3,7 @@
     ./common/core
     ./common/optional/desktop/darwin.nix
     ./common/optional/kubernetes.nix
+    ./common/optional/rust.nix
   ];
 
   # specify my home-manager configs
@@ -99,7 +100,6 @@
     unstable.sqlite
     unstable.mob
     pkgs.garden
-    unstable.rustup
     unstable.jujutsu
     unstable.minio-client
     unstable.kanata


### PR DESCRIPTION
Extract rust development tools from core user packages into optional  module for selective deployment:

- Add rustup to rust.nix optional module
- Enable selective installation on systems needing rust development