### PR TITLE
refactor: modularize development and SCM tools

### DIFF
--- a/users/refnode/common/optional/development.nix
+++ b/users/refnode/common/optional/development.nix
@@ -1,0 +1,20 @@
+{ pkgs, ... }:
+
+{
+  # General development and SCM tools
+  
+  home.packages = with pkgs; [
+    # SCM tools
+    git-annex
+    git-bug
+    gh
+    unstable.lazygit
+    unstable.glab
+    
+    # refnode's own tooling
+    ref-git-bare-clone-update
+    
+    # Development utilities
+    cookiecutter
+  ];
+}

--- a/users/refnode/default.nix
+++ b/users/refnode/default.nix
@@ -7,6 +7,7 @@
     ./common/optional/mailtools.nix
     ./common/optional/backup.nix
     ./common/optional/golang.nix
+    ./common/optional/development.nix
   ];
 
   # specify my home-manager configs
@@ -33,12 +34,7 @@
     ref-main
     ref-irc
     ref-pathlist
-    ref-git-bare-clone-update
-    cookiecutter
     qmk
-    git-annex
-    git-bug
-    gh
     gopass
     gopass-jsonapi
     zenith
@@ -72,8 +68,6 @@
     unstable.ripgrep
     unstable.awscli2
     unstable.google-cloud-sdk
-    unstable.lazygit
-    unstable.glab
     unstable.graphviz
     unstable.plantuml-c4
     unstable.ffmpeg_7


### PR DESCRIPTION
Extract development and SCM tools from core user packages into optional module:

- Add SCM tools: git-annex, git-bug, gh, lazygit, glab
- Add refnode's own tooling: ref-git-bare-clone-update  
- Add development utilities: cookiecutter